### PR TITLE
config.yaml: set publish url to aoscloud.io (aos-signer)

### DIFF
--- a/meta/config.yaml
+++ b/meta/config.yaml
@@ -6,7 +6,7 @@ build:
     remove_non_regular_files: True
 
 publish:
-    url: staging-fusion.westeurope.cloudapp.azure.com
+    url: aoscloud.io
     service_uid: # Your Service UID from the Cloud
     tls_key: private_key.pem
     tls_certificate: sp-client.pem


### PR DESCRIPTION
The current Aos Cloud Guide has a hello-world tutorial. To successfully complete the tutorial you need to change the meta/config.yaml publish url but this is not mentioned in the guide. Make the change in the source on the aos-signer branch.